### PR TITLE
Scavenger suit's fix

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -62,6 +62,7 @@
 	item_state = "scavenger"
 	armor = list("melee" = 35, "bullet" = 35, "laser" = 35, "energy" = 45, "bomb" = 35, "bio" = 55, "rad" = 55, "fire" = 55, "acid" = 55)
 	hoodtype = /obj/item/clothing/head/hooded/scavenger
+	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/armor/hos


### PR DESCRIPTION
It had no protected zones, this PR fixes that. Now they're similar to armor vest.
Doesn't follow the template, but idk if a quick fix really should.
_It should._